### PR TITLE
Remove use of bower from the project

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,8 +1,0 @@
-{
-	"registry": {
-		"search": [
-			"https://origami-bower-registry.ft.com",
-			"https://registry.bower.io"
-		]
-	}
-}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,5 +13,4 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
-    - run: npx bower install
     - run: make ci

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ So if you create an `SvgTintStream` with a color of `#ff0000`, the following sty
 
 ## Contributing
 
-To contribute to SVG Tint Stream, clone this repo locally and commit your code on a separate branch. You'll need to install [Bower] and run `bower install` to load in the SVG fixtures we use for testing.
+To contribute to SVG Tint Stream, clone this repo locally and commit your code on a separate branch.
 
 Please write unit tests for your code, and check that everything works by running the following before opening a pull-request:
 
@@ -181,7 +181,6 @@ If you have any questions or comments about `svg-tint-stream`, or need help usin
 
 This software is published by the Financial Times under the [MIT licence][license].
 
-[bower]: https://bower.io/
 [express]: https://expressjs.com/
 [license]: http://opensource.org/licenses/MIT
 [node]: https://nodejs.org/

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,0 @@
-{
-  "name": "svg-tint-stream",
-  "dependencies": {
-    "o-icons": "^4"
-  }
-}

--- a/test/integration/svg-tint-stream.test.js
+++ b/test/integration/svg-tint-stream.test.js
@@ -6,8 +6,7 @@ const path = require('path');
 const SvgTintStream = require('../../lib/svg-tint-stream');
 
 const fixtures = getFixtureList([
-	path.resolve(__dirname, 'fixture'),
-	path.resolve(__dirname, '../../bower_components/o-icons/svg')
+	path.resolve(__dirname, 'fixture')
 ]);
 
 describe('streaming SVGs', () => {


### PR DESCRIPTION
svg-tint-stream was using the svgs from an old version of o-icons as part of it's testing fixtures. I've not replaced that with anything else because svg-tint-stream also has it's own svgs it uses as testing fixtures which should be enough.

If we want more fixtures included, we could copy the ones from the old version of o-icons and commit them as fixtures within this repo, what do we think?