### PR TITLE
Added support for RGBA hex colors.

### DIFF
--- a/lib/svg-tint-stream.js
+++ b/lib/svg-tint-stream.js
@@ -35,7 +35,7 @@ module.exports = class SvgTintStream extends TransformStream {
 		if (this.options.color.indexOf('#') === -1) {
 			this.options.color = `#${this.options.color}`;
 		}
-		if (!/^#([a-f0-9]{3}|[a-f0-9]{6})$/i.test(this.options.color)) {
+		if (!/^#([a-f0-9]{3}|[a-f0-9]{6}|[a-f0-9]{8})$/i.test(this.options.color)) {
 			throw new Error('Tint color must be a valid hex code');
 		}
 	}


### PR DESCRIPTION
We found that using RGBA hex codes did not work, only 3 and 6 digit hex codes . Adding a simple regex pattern solves this issue for us, so that #ff000033 is supported.

